### PR TITLE
Removed hardcoded version string, added gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target/
+Cargo.lock

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use std::env;
 mod base;
 
-static VERSION: &str = "0.4.2";
+static VERSION: &str = env!("CARGO_PKG_VERSION");
 
 fn main() {
     let args: Vec<String> = env::args().collect();


### PR DESCRIPTION
Nice project! Here's a few changes. 

- I added in a `.gitignore` file, just to make sure that nobody pushes the `target/` folder and `Cargo.lock` file to the repository. I thought that cargo automatically added one for you, maybe you removed it on purpose?, in that case I can remove it for you, no problems. 
- I also added in a neat solution to provide a version string at compile time, rather than having it hard coded (which I can imagine is quite annoying, especially if you forget to bump it every now and then).

Good luck for future development :) [ and thanks for choosing Rust ;) ]

