### PR TITLE
Replace error handler functions with macro rules

### DIFF
--- a/examples/error.comfy
+++ b/examples/error.comfy
@@ -1,0 +1,5 @@
+// Hello there
+echo Testing blank line
+
+echo Testing error
+@ test

--- a/examples/user.comfy
+++ b/examples/user.comfy
@@ -1,0 +1,8 @@
+> linux
+echo Linux user here!
+> windows
+echo Windows user here!
+> linux
+echo Linux user here! x2
+> windows
+echo Windows user here! x2

--- a/examples/wait.comfy
+++ b/examples/wait.comfy
@@ -1,0 +1,9 @@
+// this is a comment
+> linux
+echo linux system!
+> windows
+echo windows system!
+> always
+echo this always runs!
+@ sleep 2000
+echo you waited 2000 ms!

--- a/src/base/error_handler.rs
+++ b/src/base/error_handler.rs
@@ -1,15 +1,28 @@
-use colored::Colorize;
+#[macro_export]
+macro_rules! err {
+    ($err: expr) => {
+        use colored::Colorize;
 
-pub fn err(err: &str) {
-    println!("error: {} -> --help", err.red());
-    std::process::exit(0);
+        eprintln!("{}: {} -> --help", "error".red(), $err);
+        std::process::exit(1);
+    };
 }
 
-pub fn err_syntax(err: &str) {
-    println!("error: {} -> exiting program", err.red());
-    std::process::exit(0);
+#[macro_export]
+macro_rules! err_syntax {
+    ($err: expr) => {
+        use colored::Colorize;
+
+        eprintln!("{}: {} -> exiting program", "error".red(), $err);
+        std::process::exit(1);
+    };
 }
 
-pub fn warning(err: &str) {
-    println!("warning: {}", err.yellow());
+#[macro_export]
+macro_rules! warning {
+    ($warn: expr) => {
+        use colored::Colorize;
+
+        eprintln!("{}: {}", "warning".yellow(), $warn);
+    };
 }

--- a/src/base/mod.rs
+++ b/src/base/mod.rs
@@ -1,5 +1,4 @@
 mod error_handler;
 mod parser;
 
-pub use error_handler::err;
 pub use parser::parse;

--- a/src/base/parser.rs
+++ b/src/base/parser.rs
@@ -1,4 +1,4 @@
-use crate::base::error_handler::{err, err_syntax, warning};
+use crate::{err, err_syntax, warning};
 use colored::Colorize;
 use std::{
     env::consts,
@@ -37,14 +37,14 @@ pub fn parse(file: &PathBuf, show_comments: bool) {
                 } else if show_comments {
                     print_line(index, &line, "sys");
                 } else if &line[..2] != "//" {
-                    warning(&format!(
+                    warning!(&format!(
                         "syntax, line {} -> {} parser does not recognize it",
                         &(index + 1),
                         &line
                     ));
                 }
             } else {
-                warning(&format!(
+                warning!(&format!(
                     "syntax, line {} -> blank lines can originate errors",
                     &(index + 1)
                 ));
@@ -60,7 +60,7 @@ fn kword(line: &str, index: usize) -> bool {
             "sleep" => {
                 print_line(index, &line, "non");
                 if !argument[2].chars().all(char::is_numeric) {
-                    err_syntax(&format!(
+                    err_syntax!(&format!(
                         "syntax error, line {} -> {} is not [int]",
                         &(index + 1),
                         &argument[2]
@@ -80,12 +80,11 @@ fn kword(line: &str, index: usize) -> bool {
                 true
             }
             _ => {
-                err_syntax(&format!(
+                err_syntax!(&format!(
                     "syntax error, line {} -> {} is not a comfy function",
                     &(index + 1),
                     &argument[1]
                 ));
-                true
             }
         }
     } else {
@@ -103,13 +102,11 @@ fn check_file(file: &PathBuf) -> bool {
         match stdin().read_line(&mut input) {
             Ok(_) => input.trim_end().to_lowercase() == "y",
             Err(e) => {
-                err(&e.to_string());
-                false
+                err!(&e.to_string());
             }
         }
     } else {
-        err_syntax(&format!("no such file named {}", file.display()));
-        false
+        err_syntax!(&format!("no such file named {}", file.display()));
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ enum Command {
 fn main() {
     let args = Arguments::from_args();
 
-    match args.subcommand.unwrap_or_else(|| Command::Run {
+    match args.subcommand.unwrap_or(Command::Run {
         file: None,
         comments: false,
     }) {


### PR DESCRIPTION
There is an unrelated change in `main.rs` to avoid warnings with cargo clippy.